### PR TITLE
React Router, generated file tree, modularized typescript interfaces, fixed filePath bugs

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -21,6 +21,7 @@ app.whenReady().then(() => {
 
 function createWindow() {
   mainWindow = new BrowserWindow({
+    // Harlan: We can create a minWidth and minHeight
     width: 800,
     height: 800,
     title: 'Pinocchio',

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,8 +1,8 @@
 import React, { useContext } from 'react';
-import ReactDom from 'react-dom';
-import Landing from './components/landing';
-//import FileProvider from './providers/FileProvider';
-
+import { Switch, Route } from 'react-router-dom';
+import Landing from './components/Landing';
+import Home from './components/Home';
+// import FileProvider from './providers/FileProvider';
 
 // const mainElement = document.createElement('div');
 // document.body.appendChild(mainElement);
@@ -10,23 +10,18 @@ import Landing from './components/landing';
 const App = () => {
   // state/context
 
-
-
-
   return (
     // <FileProvider>
-
     <div>
-      <h1>
-        poof
-    </h1>
-      <Landing />
-
+      <Switch>
+        <Route exact path="/" component={Landing}/>
+        <Route exact path="/home" component={Home}/>
+      </Switch>
     </div >
     // </FileProvider >
 
   )
-}
+};
 
 // ReactDom.render(<App />, mainElement);
 

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+function Home() {
+  return (
+    <h1>Hi Home!</h1>
+  );
+}
+
+export default Home;

--- a/src/components/landing.tsx
+++ b/src/components/landing.tsx
@@ -1,26 +1,55 @@
 import React, { useContext } from 'react';
 import { FileContext } from '../providers/FileProvider';
+import { fileInterface } from '../utils/fileTypes';
 
 const { remote } = window.require('electron');
 const electronFs = remote.require('fs');
+
 // Display native system dialogs for opening and saving files, alerting, etc.
 const { dialog } = remote;
 
 const Landing = () => {
   const { myPath, pathHandler } = useContext(FileContext);
+  let mainDirectory: string = '';
+  const filePathMap: any = {};
+
+  const generateFileTree = (directory: string) => {
+    // eslint-disable-next-line max-len
+    const fileArray: Array<fileInterface> | fileInterface = electronFs.readdirSync(directory).map((fileName: string) => {
+      const filePath: string = `${directory}\\${fileName}`;
+      const file: fileInterface = {
+        filePath,
+        fileName,
+        files: [],
+      };
+      const fileData: any = electronFs.statSync(file.filePath);
+      if (file.fileName !== 'node_modules' && file.fileName !== '.git') {
+        if (fileData.isDirectory()) {
+          file.files = generateFileTree(file.filePath);
+          file.files.forEach((nestedFile: fileInterface) => {
+            const javaScriptFileTypes: Array<string> = ['js', 'jsx', 'ts', 'tsx'];
+            const fileType = nestedFile.fileName.split('.')[1];
+            if (javaScriptFileTypes.includes(fileType)) {
+              const componentName: string = nestedFile.fileName.split('.')[0];
+              filePathMap[componentName] = nestedFile.filePath;
+            }
+          });
+        }
+      }
+      return file;
+    });
+    console.log(fileArray);
+    return fileArray;
+  };
 
   // returns file path of desired project folder
   const handleUploadButton = () => {
     console.log("You clicked me; dialog: ", dialog);
-    // showOpenDialog is an electron method that returns a string of file path
-    // from user's local machine
+    // showOpenDialog is an electron method that returns file path from user's local machine
     // filter the directory path a user can choose depending on file extension
-    // TODO Create type reference for filePath to be an array
-    // OR
-    // Create type for filePath[0] to be string
     dialog.showOpenDialog(
       {
-        properties: ['openDirectory', 'multiSelections'],
+        properties: ['openDirectory', 'openFile'],
         message: 'Please choose a project',
         filters: [
           { name: 'Javascript Files', extensions: ['js', 'jsx'] },
@@ -29,12 +58,13 @@ const Landing = () => {
           { name: 'Html', extensions: ['html'] },
         ],
       },
-    ).then((filePath) => pathHandler(filePath.filePaths[0]));
-    // TODO
-    // console.log(filePath);
-    // pathHandler(filePath);
-
-    // invoke that context pathhandler function here
+    )
+      .then((filePath) => {
+        mainDirectory = filePath.filePaths[0];
+        generateFileTree(mainDirectory);
+        pathHandler(filePath.filePaths[0]);
+      })
+      .catch((err: any) => console.log(err));
   };
 
   return (

--- a/src/components/landing.tsx
+++ b/src/components/landing.tsx
@@ -1,4 +1,5 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
+import { Redirect, Link } from 'react-router-dom';
 import { FileContext } from '../providers/FileProvider';
 
 const { remote } = window.require('electron');
@@ -8,6 +9,7 @@ const { dialog } = remote;
 
 const Landing = () => {
   const { myPath, pathHandler } = useContext(FileContext);
+  const [pathUploaded, setPathUploaded] = useState(false);
 
   // returns file path of desired project folder
   const handleUploadButton = () => {
@@ -29,21 +31,30 @@ const Landing = () => {
           { name: 'Html', extensions: ['html'] },
         ],
       },
-    ).then((filePath) => pathHandler(filePath.filePaths[0]));
-    // TODO
-    // console.log(filePath);
-    // pathHandler(filePath);
-
-    // invoke that context pathhandler function here
+    )
+    // invoked the pathhandler function from our fileProvider.ts
+      .then((res) => {
+        console.log(res);
+        pathHandler(res.filePaths[0]);
+      })
+    // if it works .then
+      .then(() => setPathUploaded(true))
+    // if it doesn't oopsie woopsie
+      .catch((err) => {
+        console.log('Error: ', err)
+      });
   };
 
+  // a boolean if something was true, redirect
+  // two return statements, the first only having the <Redirect />
+  if (pathUploaded) return <Redirect to='/home' />;
+  // the actual return
   return (
     <div>
       <button onClick={handleUploadButton}>UPLOAD</button>
       <h1>{myPath}</h1>
-
     </div>
-  )
-}
+  );
+};
 
 export default Landing;

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import App from './app.tsx'
+import { BrowserRouter } from 'react-router-dom';
+import App from './app.tsx';
 import FileProvider from './providers/FileProvider';
 
 const main = document.createElement('div');
 document.body.appendChild(main);
 
 ReactDOM.render(
-  <FileProvider>
-    <App />
-  </FileProvider >,
-  main);
+  <BrowserRouter>
+    <FileProvider>
+      <App />
+    </FileProvider>
+  </BrowserRouter>,
+  main
+);

--- a/src/providers/FileProvider.tsx
+++ b/src/providers/FileProvider.tsx
@@ -15,6 +15,7 @@ const FileProvider = (props) => {
   const pathHandler = (pathValue: string) => {
     console.log('hitting provider handler');
     setMyPath(pathValue);
+    // redirect logic here
   };
 
   return (

--- a/src/utils/fileTypes.ts
+++ b/src/utils/fileTypes.ts
@@ -1,0 +1,5 @@
+export interface fileInterface {
+  filePath: string,
+  fileName: string,
+  files: Array<file> | file
+}


### PR DESCRIPTION
## Type of change

- [x] Bug fix (change which fixes an issue)

- [x] New Feature (change which adds functionality)

- [x] Refactor (change which changes the codebase without affecting its behavior)

- [x] Non-breaking change (fix or feature that would cause existing functionality to work as expected)

- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)

## The problem you are solving
Couldn't re-route to home page
Didn't have access to file tree structure
Lacked some compatibility with ESLint
Lacked compatibility with accessing file paths with OSX and PC
Typescript interfaces were not modularized

## Your solution to the problem
Created a home page
Implemented React Router to redirect from landing to home page
Implemented generateFileTree function to access files that are selected from user machine
Updated eslintrc file
Fixed filePath bug with Regex
Designated types for fileInterface

## Any notes on testing this functionality

## Screenshots
<img width="1299" alt="Screen Shot 2021-01-14 at 5 04 15 PM" src="https://user-images.githubusercontent.com/58094472/104667380-caa1a980-568a-11eb-9696-39be8af0c71a.png">
<img width="1258" alt="Screen Shot 2021-01-14 at 5 04 33 PM" src="https://user-images.githubusercontent.com/58094472/104667389-ce353080-568a-11eb-8163-74486c98113e.png">
<img width="1203" alt="Screen Shot 2021-01-14 at 5 05 38 PM" src="https://user-images.githubusercontent.com/58094472/104667396-d2614e00-568a-11eb-8ad5-120af5d3dd9c.png">
